### PR TITLE
FIX: cardinal type undefined 삭제

### DIFF
--- a/lib/bsmOauth.ts
+++ b/lib/bsmOauth.ts
@@ -87,15 +87,7 @@ export default class BsmOauth {
     const isGraduate = !grade && !classNo && !studentNo;
     const cardinal = enrolledAt && enrolledAt - this.CARDINAL_BASE_YEAR;
 
-    return {
-      name,
-      enrolledAt,
-      grade,
-      classNo,
-      studentNo,
-      isGraduate,
-      cardinal
-    };
+    return { name, enrolledAt, grade, classNo, studentNo, isGraduate, cardinal };
   }
 
   private toTeacher(resource: RawBsmOAuthResource): BsmTeacher {

--- a/lib/types/student.ts
+++ b/lib/types/student.ts
@@ -8,7 +8,7 @@ export interface BsmStudent {
   readonly classNo: number;
   readonly studentNo: number;
   readonly isGraduate: boolean;
-  readonly cardinal?: number;
+  readonly cardinal: number;
 }
 
 export interface BsmStudentResource extends CommonResource {


### PR DESCRIPTION
## 작업
- cardinal type undefined 삭제

## 할 말
클라이언트에서 라이브러리를 사용할때
<img width="235" alt="image" src="https://github.com/leehj050211/bsm-oauth-js/assets/102217654/73cbfdde-1cb5-4619-9f39-72ddb694a306">
다음과 같이 표시되어 클라이언트에서 undefiend type을 지정해줘야합니다 하지만 지운다고하면 의도한대로 입학연도가 없으면 undefiend가 들어가고 client에서는 undefiend type을 지정하지 않아도 됩니다